### PR TITLE
s/MACOSX/__APPLE__/

### DIFF
--- a/tty/forkpty.cc
+++ b/tty/forkpty.cc
@@ -6,7 +6,7 @@
 #include <sys/ioctl.h>
 #include <errno.h>
 
-#ifdef MACOSX
+#ifdef __APPLE__
 # include <util.h>
 #else
 # include <pty.h>


### PR DESCRIPTION
The constant "`MACOSX`" didn't work for me, but I could make it work by using "`__APPLE__`".